### PR TITLE
Refactor usePhotoNavigation to reduce cognitive complexity

### DIFF
--- a/src/components/PhotoModal/PhotoModal.tsx
+++ b/src/components/PhotoModal/PhotoModal.tsx
@@ -5,7 +5,7 @@ import PhotoModalNavigation from './PhotoModalNavigation';
 import useBodyScrollLock from './useBodyScrollLock';
 import useCloseModal from './useCloseModal';
 import usePhotoModalStateManager from './usePhotoModalStateManager';
-import usePhotoNavigation from './usePhotoNavigation';
+import { usePhotoNavigation } from './usePhotoNavigation';
 import useSyncUrlWithSelectedPhoto from './useSyncUrlWithSelectedPhoto';
 
 const PhotoModal = () => {

--- a/src/components/PhotoModal/usePhotoNavigation.ts
+++ b/src/components/PhotoModal/usePhotoNavigation.ts
@@ -1,8 +1,7 @@
-// usePhotoNavigation.ts
 import useOpenModal from '@/components/PhotoModal/useOpenModal';
 import { useNavigate } from 'react-router-dom';
 
-const usePhotoNavigation = (
+export const usePhotoNavigation = (
   photos: (Photo | Collection)[] | undefined,
   selectedPhotoId: string | undefined,
 ) => {
@@ -10,19 +9,15 @@ const usePhotoNavigation = (
   const navigate = useNavigate();
 
   const handleNavigation = (offset: number) => {
-    if (!photos || !selectedPhotoId) return;
-
-    const currentIndex = photos.findIndex((p) => p.id === selectedPhotoId);
-    const newIndex = currentIndex + offset;
-
-    if (newIndex >= 0 && newIndex < photos.length) {
-      const newPhoto = photos[newIndex]; // Get the full photo or collection object
-      navigate(`/photos/${newPhoto.id}`, { replace: true });
-      openModal(newPhoto, photos as any);
+    const currentIndex = photos?.findIndex(p => p.id === selectedPhotoId);
+    const newIndex = currentIndex !== undefined && currentIndex >= 0 ? currentIndex + offset : -1;
+    const safePhotos = photos || [];
+    const photo = newIndex >= 0 && newIndex < safePhotos.length ? safePhotos[newIndex] : null;
+    if (photo) {
+      navigate(`/photos/${photo.id}`, { replace: true });
+      openModal(photo, photos as any);
     }
   };
 
   return { handleNavigation };
 };
-
-export default usePhotoNavigation;


### PR DESCRIPTION
Simplify the logic for calculating the new index and retrieving the photo object to reduce cognitive complexity, making the function easier to understand and maintain.